### PR TITLE
修正从 0.x.x.x 老版本升级上来后出现的报错

### DIFF
--- a/src/background/environment/settings.js
+++ b/src/background/environment/settings.js
@@ -8,6 +8,7 @@ import storage from './storage'
 import features from '@features'
 import isFanfouWebUrl from '@libs/isFanfouWebUrl'
 import migrate from '@libs/migrate'
+import isExtensionUpgraded from '@libs/isExtensionUpgraded'
 import { readJSONFromLocalStorage } from '@libs/localStorageWrappers'
 import getExtensionVersion from '@libs/getExtensionVersion'
 import omitBy from '@libs/omitBy'
@@ -189,10 +190,6 @@ async function checkIfExtensionUpgraded() {
     PREVIOUS_EXTENSION_VERSION_STORAGE_AREA_NAME,
   )
   const currentVersion = getExtensionVersion()
-  const isExtensionUpgraded = (
-    !!previousVersion &&
-    semver.gt(currentVersion, previousVersion)
-  )
 
   await storage.write(
     PREVIOUS_EXTENSION_VERSION_STORAGE_KEY,
@@ -201,7 +198,7 @@ async function checkIfExtensionUpgraded() {
   )
   await storage.write(
     STORAGE_KEY_IS_EXTENSION_UPGRADED,
-    isExtensionUpgraded,
+    isExtensionUpgraded(previousVersion, currentVersion),
     STORAGE_AREA_NAME_IS_EXTENSION_UPGRADED,
   )
 }

--- a/src/libs/isExtensionUpgraded.js
+++ b/src/libs/isExtensionUpgraded.js
@@ -1,0 +1,10 @@
+import semver from 'semver'
+import isLegacyVersion from '@libs/isLegacyVersion'
+
+export default (previousVersion, currentVersion) => {
+  // 新安装，没有检查到旧版本号
+  if (!previousVersion) return false
+  // 检查到老的 '0.x.x.x' 版本号，但是这个不能直接传给 semver，会报错
+  if (isLegacyVersion(previousVersion)) return true
+  return semver.gt(currentVersion, previousVersion)
+}

--- a/src/libs/isExtensionUpgraded.test.js
+++ b/src/libs/isExtensionUpgraded.test.js
@@ -1,0 +1,8 @@
+import isExtensionUpgraded from './isExtensionUpgraded'
+
+test('isExtensionUpgraded', () => {
+  expect(isExtensionUpgraded(null, '1.0.0')).toBe(false)
+  expect(isExtensionUpgraded('0.9.8.9', '1.0.0')).toBe(true)
+  expect(isExtensionUpgraded('1.0.0', '1.0.0')).toBe(false)
+  expect(isExtensionUpgraded('1.0.0', '1.0.1')).toBe(true)
+})

--- a/src/libs/isLegacyVersion.js
+++ b/src/libs/isLegacyVersion.js
@@ -1,0 +1,5 @@
+// 判断版本号是否为 '0.x.x.x' 的格式
+export default version => (
+  typeof version === 'string' &&
+  /^0\.\d\.\d\.\d$/.test(version)
+)

--- a/src/libs/isLegacyVersion.test.js
+++ b/src/libs/isLegacyVersion.test.js
@@ -1,0 +1,6 @@
+import isLegacyVersion from './isLegacyVersion'
+
+test('isLegacyVersion', () => {
+  expect(isLegacyVersion('0.9.8.9')).toBe(true)
+  expect(isLegacyVersion('1.0.0')).toBe(false)
+})


### PR DESCRIPTION
之前遇到 `semver('1.0.0', '0.9.8.9')` 这种情况会报错，semver 认为 `0.9.8.9` 这个版本号是非法的。